### PR TITLE
Save Module Config: Add Save Command

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -21,17 +21,20 @@ import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.Logic;
 import seedu.address.logic.LogicManager;
 import seedu.address.model.AddressBook;
+import seedu.address.model.ConfigStore;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.util.SampleDataUtil;
 import seedu.address.storage.AddressBookStorage;
+import seedu.address.storage.ConfigStoreStorage;
 import seedu.address.storage.JsonUserPrefsStorage;
 import seedu.address.storage.Storage;
 import seedu.address.storage.StorageManager;
 import seedu.address.storage.UserPrefsStorage;
 import seedu.address.storage.XmlAddressBookStorage;
+import seedu.address.storage.XmlConfigStoreStorage;
 import seedu.address.ui.Ui;
 import seedu.address.ui.UiManager;
 
@@ -63,7 +66,9 @@ public class MainApp extends Application {
         UserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(config.getUserPrefsFilePath());
         userPrefs = initPrefs(userPrefsStorage);
         AddressBookStorage addressBookStorage = new XmlAddressBookStorage(userPrefs.getAddressBookFilePath());
-        storage = new StorageManager(addressBookStorage, userPrefsStorage);
+        ConfigStoreStorage credentialStoreStorage = new XmlConfigStoreStorage(userPrefs.getUserConfigFilePath());
+
+        storage = new StorageManager(addressBookStorage, userPrefsStorage, credentialStoreStorage);
 
         initLogging(config);
 
@@ -98,7 +103,23 @@ public class MainApp extends Application {
             initialData = new AddressBook();
         }
 
-        return new ModelManager(initialData, userPrefs);
+        Optional<ConfigStore> configStoreOptional;
+        ConfigStore configStore;
+        try {
+            configStoreOptional = storage.readConfigStore();
+            if (!configStoreOptional.isPresent()) {
+                logger.info("Data file not found. Will be starting with a sample AddressBook");
+            }
+            configStore = configStoreOptional.orElse(new ConfigStore());
+        } catch (DataConversionException e) {
+            logger.warning("Data file not in the correct format. Will be starting with an empty AddressBook");
+            configStore = new ConfigStore();
+        } catch (IOException e) {
+            logger.warning("Problem while reading from the file. Will be starting with an empty AddressBook");
+            configStore = new ConfigStore();
+        }
+
+        return new ModelManager(initialData, userPrefs, configStore);
     }
 
     private void initLogging(Config config) {

--- a/src/main/java/seedu/address/commons/events/model/ConfigStoreChangedEvent.java
+++ b/src/main/java/seedu/address/commons/events/model/ConfigStoreChangedEvent.java
@@ -3,7 +3,7 @@ package seedu.address.commons.events.model;
 import seedu.address.commons.events.BaseEvent;
 import seedu.address.model.ConfigStore;
 
-/** Indicates the CredentialStore in the model has changed*/
+/** Indicates the ConfigStore in the model has changed*/
 public class ConfigStoreChangedEvent extends BaseEvent {
     public final ConfigStore data;
 

--- a/src/main/java/seedu/address/commons/events/model/ConfigStoreChangedEvent.java
+++ b/src/main/java/seedu/address/commons/events/model/ConfigStoreChangedEvent.java
@@ -4,16 +4,15 @@ import seedu.address.commons.events.BaseEvent;
 import seedu.address.model.ConfigStore;
 
 /** Indicates the CredentialStore in the model has changed*/
-public class ConfigStoreChangedEvent extends BaseEvent{
+public class ConfigStoreChangedEvent extends BaseEvent {
+    public final ConfigStore data;
 
-  public final ConfigStore data;
+    public ConfigStoreChangedEvent(ConfigStore data) {
+        this.data = data;
+    }
 
-  public ConfigStoreChangedEvent(ConfigStore data) {
-    this.data = data;
-  }
-
-  @Override
-  public String toString() {
-    return "Byte size of config data: " + data.getConfigData().length;
-  }
+    @Override
+    public String toString() {
+        return "Byte size of config data: " + data.getConfigData().length;
+    }
 }

--- a/src/main/java/seedu/address/commons/events/model/ConfigStoreChangedEvent.java
+++ b/src/main/java/seedu/address/commons/events/model/ConfigStoreChangedEvent.java
@@ -1,0 +1,19 @@
+package seedu.address.commons.events.model;
+
+import seedu.address.commons.events.BaseEvent;
+import seedu.address.model.ConfigStore;
+
+/** Indicates the CredentialStore in the model has changed*/
+public class ConfigStoreChangedEvent extends BaseEvent{
+
+  public final ConfigStore data;
+
+  public ConfigStoreChangedEvent(ConfigStore data) {
+    this.data = data;
+  }
+
+  @Override
+  public String toString() {
+    return "Byte size of config data: " + data.getConfigData().length;
+  }
+}

--- a/src/main/java/seedu/address/logic/commands/SaveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SaveCommand.java
@@ -7,7 +7,7 @@ import seedu.address.model.Config;
 import seedu.address.model.Model;
 
 /**
- * Clears the address book.
+ * Saves the module configuration.
  */
 public class SaveCommand extends Command {
 
@@ -25,11 +25,8 @@ public class SaveCommand extends Command {
     @Override
     public CommandResult execute(Model model, CommandHistory history) {
         requireNonNull(model);
-        System.out.println("execute 1");
         model.saveConfigFile(toSaveConfig);
-        System.out.println("execute 2");
         model.commitAddressBook();
-        System.out.println("execute 3");
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/SaveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SaveCommand.java
@@ -11,25 +11,25 @@ import seedu.address.model.Model;
  */
 public class SaveCommand extends Command {
 
-  public static final String COMMAND_WORD = "save";
-  public static final String MESSAGE_SUCCESS = "Current module configuration has be saved!";
+    public static final String COMMAND_WORD = "save";
+    public static final String MESSAGE_SUCCESS = "Current module configuration has be saved!";
 
-  private final Config toSaveConfig;
+    private final Config toSaveConfig;
 
-  public SaveCommand(Config newConfig) {
-    requireNonNull(newConfig);
-    toSaveConfig = newConfig;
-  }
+    public SaveCommand(Config newConfig) {
+        requireNonNull(newConfig);
+        toSaveConfig = newConfig;
+    }
 
 
-  @Override
-  public CommandResult execute(Model model, CommandHistory history) {
-    requireNonNull(model);
-    System.out.println("execute 1");
-    model.saveConfigFile(toSaveConfig);
-    System.out.println("execute 2");
-    model.commitAddressBook();
-    System.out.println("execute 3");
-    return new CommandResult(MESSAGE_SUCCESS);
-  }
+    @Override
+    public CommandResult execute(Model model, CommandHistory history) {
+        requireNonNull(model);
+        System.out.println("execute 1");
+        model.saveConfigFile(toSaveConfig);
+        System.out.println("execute 2");
+        model.commitAddressBook();
+        System.out.println("execute 3");
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/SaveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SaveCommand.java
@@ -3,7 +3,7 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 
 import seedu.address.logic.CommandHistory;
-import seedu.address.model.AddressBook;
+import seedu.address.model.Config;
 import seedu.address.model.Model;
 
 /**
@@ -14,13 +14,22 @@ public class SaveCommand extends Command {
   public static final String COMMAND_WORD = "save";
   public static final String MESSAGE_SUCCESS = "Current module configuration has be saved!";
 
+  private final Config toSaveConfig;
+
+  public SaveCommand(Config newConfig) {
+    requireNonNull(newConfig);
+    toSaveConfig = newConfig;
+  }
+
 
   @Override
   public CommandResult execute(Model model, CommandHistory history) {
     requireNonNull(model);
-//    model.resetData(new AddressBook());
-//    model.commitAddressBook();
-    System.out.println("Savecommand.java executed");
+    System.out.println("execute 1");
+    model.saveConfigFile(toSaveConfig);
+    System.out.println("execute 2");
+    model.commitAddressBook();
+    System.out.println("execute 3");
     return new CommandResult(MESSAGE_SUCCESS);
   }
 }

--- a/src/main/java/seedu/address/logic/commands/SaveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SaveCommand.java
@@ -1,0 +1,26 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.logic.CommandHistory;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+
+/**
+ * Clears the address book.
+ */
+public class SaveCommand extends Command {
+
+  public static final String COMMAND_WORD = "save";
+  public static final String MESSAGE_SUCCESS = "Current module configuration has be saved!";
+
+
+  @Override
+  public CommandResult execute(Model model, CommandHistory history) {
+    requireNonNull(model);
+//    model.resetData(new AddressBook());
+//    model.commitAddressBook();
+    System.out.println("Savecommand.java executed");
+    return new CommandResult(MESSAGE_SUCCESS);
+  }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -58,13 +58,15 @@ public class AddressBookParser {
             return new EditCommandParser().parse(arguments);
 
         case SaveCommand.COMMAND_WORD:
+            // Prepare for next version
             try {
                 return new SaveCommand(new Config("hello".getBytes("UTF-8")));
             } catch (UnsupportedEncodingException e) {
                 e.printStackTrace();
+                return null;
             }
 
-            case SelectCommand.COMMAND_WORD:
+        case SelectCommand.COMMAND_WORD:
             return new SelectCommandParser().parse(arguments);
 
         case DeleteCommand.COMMAND_WORD:

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -17,6 +17,7 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.HistoryCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.RedoCommand;
+import seedu.address.logic.commands.SaveCommand;
 import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -53,6 +54,9 @@ public class AddressBookParser {
 
         case EditCommand.COMMAND_WORD:
             return new EditCommandParser().parse(arguments);
+
+        case SaveCommand.COMMAND_WORD:
+            return new SaveCommand();
 
         case SelectCommand.COMMAND_WORD:
             return new SelectCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 
+import java.io.UnsupportedEncodingException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -21,6 +22,7 @@ import seedu.address.logic.commands.SaveCommand;
 import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.Config;
 
 /**
  * Parses user input.
@@ -56,9 +58,13 @@ public class AddressBookParser {
             return new EditCommandParser().parse(arguments);
 
         case SaveCommand.COMMAND_WORD:
-            return new SaveCommand();
+            try {
+                return new SaveCommand(new Config("hello".getBytes("UTF-8")));
+            } catch (UnsupportedEncodingException e) {
+                e.printStackTrace();
+            }
 
-        case SelectCommand.COMMAND_WORD:
+            case SelectCommand.COMMAND_WORD:
             return new SelectCommandParser().parse(arguments);
 
         case DeleteCommand.COMMAND_WORD:

--- a/src/main/java/seedu/address/model/Config.java
+++ b/src/main/java/seedu/address/model/Config.java
@@ -1,15 +1,18 @@
 package seedu.address.model;
 
+/**
+ * Config data
+ */
 public class Config {
 
-  private final byte[] configData;
+    private final byte[] configData;
 
-  public Config (byte[] data) {
-    this.configData = data;
-  }
+    public Config (byte[] data) {
+        this.configData = data;
+    }
 
-  public byte[] getConfigData() {
-    return configData;
-  }
+    public byte[] getConfigData() {
+        return configData;
+    }
 
 }

--- a/src/main/java/seedu/address/model/Config.java
+++ b/src/main/java/seedu/address/model/Config.java
@@ -1,0 +1,15 @@
+package seedu.address.model;
+
+public class Config {
+
+  private final byte[] configData;
+
+  public Config (byte[] data) {
+    this.configData = data;
+  }
+
+  public byte[] getConfigData() {
+    return configData;
+  }
+
+}

--- a/src/main/java/seedu/address/model/ConfigStore.java
+++ b/src/main/java/seedu/address/model/ConfigStore.java
@@ -1,0 +1,18 @@
+package seedu.address.model;
+
+/**
+ * Wraps all Configuration data
+ */
+public class ConfigStore {
+
+  private byte[] configData;
+
+  public void addConfigData (Config config){
+      configData = config.getConfigData();
+  }
+
+  public byte[] getConfigData(){
+    return configData;
+  }
+
+}

--- a/src/main/java/seedu/address/model/ConfigStore.java
+++ b/src/main/java/seedu/address/model/ConfigStore.java
@@ -4,15 +4,13 @@ package seedu.address.model;
  * Wraps all Configuration data
  */
 public class ConfigStore {
+    private byte[] configData;
 
-  private byte[] configData;
+    public void addConfigData (Config config) {
+        configData = config.getConfigData();
+    }
 
-  public void addConfigData (Config config){
-      configData = config.getConfigData();
-  }
-
-  public byte[] getConfigData(){
-    return configData;
-  }
-
+    public byte[] getConfigData() {
+        return configData;
+    }
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -75,4 +75,9 @@ public interface Model {
      * Saves the current address book state for undo/redo.
      */
     void commitAddressBook();
+
+    /**
+     * Saves the current configuration.
+     */
+    void saveConfigFile(Config c);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -26,7 +26,7 @@ public class ModelManager extends ComponentManager implements Model {
     private final ConfigStore configStore;
 
     /**
-     * Initializes a ModelManager with the given addressBook and userPrefs.
+     * Initializes a ModelManager with the given addressBook, userPrefs and configStore.
      */
     public ModelManager(ReadOnlyAddressBook addressBook, UserPrefs userPrefs, ConfigStore configStore) {
         super();

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -12,6 +12,7 @@ import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.ComponentManager;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.events.model.AddressBookChangedEvent;
+import seedu.address.commons.events.model.ConfigStoreChangedEvent;
 import seedu.address.model.person.Person;
 
 /**
@@ -22,11 +23,12 @@ public class ModelManager extends ComponentManager implements Model {
 
     private final VersionedAddressBook versionedAddressBook;
     private final FilteredList<Person> filteredPersons;
+    private final ConfigStore configStore;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
      */
-    public ModelManager(ReadOnlyAddressBook addressBook, UserPrefs userPrefs) {
+    public ModelManager(ReadOnlyAddressBook addressBook, UserPrefs userPrefs, ConfigStore configStore) {
         super();
         requireAllNonNull(addressBook, userPrefs);
 
@@ -34,10 +36,11 @@ public class ModelManager extends ComponentManager implements Model {
 
         versionedAddressBook = new VersionedAddressBook(addressBook);
         filteredPersons = new FilteredList<>(versionedAddressBook.getPersonList());
+        this.configStore = configStore;
     }
 
     public ModelManager() {
-        this(new AddressBook(), new UserPrefs());
+        this(new AddressBook(), new UserPrefs(), new ConfigStore());
     }
 
     @Override
@@ -127,6 +130,18 @@ public class ModelManager extends ComponentManager implements Model {
     @Override
     public void commitAddressBook() {
         versionedAddressBook.commit();
+    }
+
+    //=========== Save Config file ==========================================================================
+    @Override
+    public void saveConfigFile(Config c) {
+        configStore.addConfigData(c);
+        triggerFileSaveConfig();
+    }
+
+    /** Raises an event to trigger the save */
+    private void triggerFileSaveConfig() {
+        raise(new ConfigStoreChangedEvent(configStore));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/UserPrefs.java
+++ b/src/main/java/seedu/address/model/UserPrefs.java
@@ -13,6 +13,7 @@ public class UserPrefs {
 
     private GuiSettings guiSettings;
     private Path addressBookFilePath = Paths.get("data" , "addressbook.xml");
+    private Path userConfigFilePath = Paths.get("data" , "userconfig.xml");
 
     public UserPrefs() {
         setGuiSettings(500, 500, 0, 0);
@@ -28,6 +29,13 @@ public class UserPrefs {
 
     public void setGuiSettings(double width, double height, int x, int y) {
         guiSettings = new GuiSettings(width, height, x, y);
+    }
+
+    public Path getUserConfigFilePath() {
+        return userConfigFilePath;
+    }
+    public void setUserConfigFilePath(Path userConfigFilePath) {
+        this.userConfigFilePath = userConfigFilePath;
     }
 
     public Path getAddressBookFilePath() {

--- a/src/main/java/seedu/address/storage/ConfigStoreStorage.java
+++ b/src/main/java/seedu/address/storage/ConfigStoreStorage.java
@@ -6,7 +6,6 @@ import java.util.Optional;
 
 import seedu.address.commons.exceptions.DataConversionException;
 import seedu.address.model.ConfigStore;
-import seedu.address.model.ReadOnlyAddressBook;
 
 /**
  * Represents a storage for {@link seedu.address.model.ConfigStore}.

--- a/src/main/java/seedu/address/storage/ConfigStoreStorage.java
+++ b/src/main/java/seedu/address/storage/ConfigStoreStorage.java
@@ -1,0 +1,46 @@
+package seedu.address.storage;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import seedu.address.commons.exceptions.DataConversionException;
+import seedu.address.model.ConfigStore;
+import seedu.address.model.ReadOnlyAddressBook;
+
+/**
+ * Represents a storage for {@link seedu.address.model.ConfigStore}.
+ */
+public interface ConfigStoreStorage {
+
+  /**
+   * Returns the file path of the data file.
+   */
+  Path getConfigStoreStorageFilePath();
+
+  /**
+   * Returns AddressBook data as a {@link ReadOnlyAddressBook}.
+   *   Returns {@code Optional.empty()} if storage file is not found.
+   * @throws DataConversionException if the data in storage is not in the expected format.
+   * @throws IOException if there was any problem when reading from the storage.
+   */
+  Optional<ConfigStore> readConfigStore() throws DataConversionException, IOException;
+
+  /**
+   * @see #getConfigStoreStorageFilePath()
+   */
+  Optional<ConfigStore> readConfigStore(Path filePath) throws DataConversionException, IOException;
+
+  /**
+   * Saves the given {@link ReadOnlyAddressBook} to the storage.
+   * @param addressBook cannot be null.
+   * @throws IOException if there was any problem writing to the file.
+   */
+  void saveConfigStore(ConfigStore addressBook) throws IOException;
+
+  /**
+   * @see #saveConfigStore(ConfigStore)
+   */
+  void saveConfigStore(ConfigStore addressBook, Path filePath) throws IOException;
+
+}

--- a/src/main/java/seedu/address/storage/ConfigStoreStorage.java
+++ b/src/main/java/seedu/address/storage/ConfigStoreStorage.java
@@ -19,7 +19,7 @@ public interface ConfigStoreStorage {
     Path getConfigStoreStorageFilePath();
 
     /**
-    * Returns AddressBook data as a {@link ReadOnlyAddressBook}.
+    * Returns ConfigStore data as a {@link ConfigStore}.
     *   Returns {@code Optional.empty()} if storage file is not found.
     * @throws DataConversionException if the data in storage is not in the expected format.
     * @throws IOException if there was any problem when reading from the storage.
@@ -32,15 +32,15 @@ public interface ConfigStoreStorage {
     Optional<ConfigStore> readConfigStore(Path filePath) throws DataConversionException, IOException;
 
     /**
-    * Saves the given {@link ReadOnlyAddressBook} to the storage.
-    * @param addressBook cannot be null.
+    * Saves the given {@link ConfigStore} to the storage.
+    * @param configStore cannot be null.
     * @throws IOException if there was any problem writing to the file.
     */
-    void saveConfigStore(ConfigStore addressBook) throws IOException;
+    void saveConfigStore(ConfigStore configStore) throws IOException;
 
     /**
     * @see #saveConfigStore(ConfigStore)
     */
-    void saveConfigStore(ConfigStore addressBook, Path filePath) throws IOException;
+    void saveConfigStore(ConfigStore configStore, Path filePath) throws IOException;
 
 }

--- a/src/main/java/seedu/address/storage/ConfigStoreStorage.java
+++ b/src/main/java/seedu/address/storage/ConfigStoreStorage.java
@@ -13,34 +13,34 @@ import seedu.address.model.ReadOnlyAddressBook;
  */
 public interface ConfigStoreStorage {
 
-  /**
-   * Returns the file path of the data file.
-   */
-  Path getConfigStoreStorageFilePath();
+    /**
+    * Returns the file path of the data file.
+    */
+    Path getConfigStoreStorageFilePath();
 
-  /**
-   * Returns AddressBook data as a {@link ReadOnlyAddressBook}.
-   *   Returns {@code Optional.empty()} if storage file is not found.
-   * @throws DataConversionException if the data in storage is not in the expected format.
-   * @throws IOException if there was any problem when reading from the storage.
-   */
-  Optional<ConfigStore> readConfigStore() throws DataConversionException, IOException;
+    /**
+    * Returns AddressBook data as a {@link ReadOnlyAddressBook}.
+    *   Returns {@code Optional.empty()} if storage file is not found.
+    * @throws DataConversionException if the data in storage is not in the expected format.
+    * @throws IOException if there was any problem when reading from the storage.
+    */
+    Optional<ConfigStore> readConfigStore() throws DataConversionException, IOException;
 
-  /**
-   * @see #getConfigStoreStorageFilePath()
-   */
-  Optional<ConfigStore> readConfigStore(Path filePath) throws DataConversionException, IOException;
+    /**
+    * @see #getConfigStoreStorageFilePath()
+    */
+    Optional<ConfigStore> readConfigStore(Path filePath) throws DataConversionException, IOException;
 
-  /**
-   * Saves the given {@link ReadOnlyAddressBook} to the storage.
-   * @param addressBook cannot be null.
-   * @throws IOException if there was any problem writing to the file.
-   */
-  void saveConfigStore(ConfigStore addressBook) throws IOException;
+    /**
+    * Saves the given {@link ReadOnlyAddressBook} to the storage.
+    * @param addressBook cannot be null.
+    * @throws IOException if there was any problem writing to the file.
+    */
+    void saveConfigStore(ConfigStore addressBook) throws IOException;
 
-  /**
-   * @see #saveConfigStore(ConfigStore)
-   */
-  void saveConfigStore(ConfigStore addressBook, Path filePath) throws IOException;
+    /**
+    * @see #saveConfigStore(ConfigStore)
+    */
+    void saveConfigStore(ConfigStore addressBook, Path filePath) throws IOException;
 
 }

--- a/src/main/java/seedu/address/storage/Storage.java
+++ b/src/main/java/seedu/address/storage/Storage.java
@@ -5,6 +5,7 @@ import java.nio.file.Path;
 import java.util.Optional;
 
 import seedu.address.commons.events.model.AddressBookChangedEvent;
+import seedu.address.commons.events.model.ConfigStoreChangedEvent;
 import seedu.address.commons.events.storage.DataSavingExceptionEvent;
 import seedu.address.commons.exceptions.DataConversionException;
 import seedu.address.model.ReadOnlyAddressBook;
@@ -13,7 +14,7 @@ import seedu.address.model.UserPrefs;
 /**
  * API of the Storage component
  */
-public interface Storage extends AddressBookStorage, UserPrefsStorage {
+public interface Storage extends AddressBookStorage, UserPrefsStorage, ConfigStoreStorage {
 
     @Override
     Optional<UserPrefs> readUserPrefs() throws DataConversionException, IOException;
@@ -36,4 +37,6 @@ public interface Storage extends AddressBookStorage, UserPrefsStorage {
      * Raises {@link DataSavingExceptionEvent} if there was an error during saving.
      */
     void handleAddressBookChangedEvent(AddressBookChangedEvent abce);
+
+    void handleConfigStoreChangedEvent(ConfigStoreChangedEvent csce);
 }

--- a/src/main/java/seedu/address/storage/Storage.java
+++ b/src/main/java/seedu/address/storage/Storage.java
@@ -38,5 +38,10 @@ public interface Storage extends AddressBookStorage, UserPrefsStorage, ConfigSto
      */
     void handleAddressBookChangedEvent(AddressBookChangedEvent abce);
 
+    /**
+     * Saves the current module configuration data to the hard disk.
+     *   Creates the data file if it is missing.
+     * Raises {@link DataSavingExceptionEvent} if there was an error during saving.
+     */
     void handleConfigStoreChangedEvent(ConfigStoreChangedEvent csce);
 }

--- a/src/main/java/seedu/address/storage/StorageManager.java
+++ b/src/main/java/seedu/address/storage/StorageManager.java
@@ -10,8 +10,10 @@ import com.google.common.eventbus.Subscribe;
 import seedu.address.commons.core.ComponentManager;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.events.model.AddressBookChangedEvent;
+import seedu.address.commons.events.model.ConfigStoreChangedEvent;
 import seedu.address.commons.events.storage.DataSavingExceptionEvent;
 import seedu.address.commons.exceptions.DataConversionException;
+import seedu.address.model.ConfigStore;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.UserPrefs;
 
@@ -23,12 +25,14 @@ public class StorageManager extends ComponentManager implements Storage {
     private static final Logger logger = LogsCenter.getLogger(StorageManager.class);
     private AddressBookStorage addressBookStorage;
     private UserPrefsStorage userPrefsStorage;
+    private ConfigStoreStorage configStoreStorage;
 
 
-    public StorageManager(AddressBookStorage addressBookStorage, UserPrefsStorage userPrefsStorage) {
+    public StorageManager(AddressBookStorage addressBookStorage, UserPrefsStorage userPrefsStorage, ConfigStoreStorage configStoreStorage) {
         super();
         this.addressBookStorage = addressBookStorage;
         this.userPrefsStorage = userPrefsStorage;
+        this.configStoreStorage = configStoreStorage;
     }
 
     // ================ UserPrefs methods ==============================
@@ -85,6 +89,46 @@ public class StorageManager extends ComponentManager implements Storage {
         logger.info(LogsCenter.getEventHandlingLogMessage(event, "Local data changed, saving to file"));
         try {
             saveAddressBook(event.data);
+        } catch (IOException e) {
+            raise(new DataSavingExceptionEvent(e));
+        }
+    }
+
+    // ================ Configuration File methods ==============================
+
+    @Override
+    public Path getConfigStoreStorageFilePath() {
+        return configStoreStorage.getConfigStoreStorageFilePath();
+    }
+
+    @Override
+    public Optional<ConfigStore> readConfigStore() throws DataConversionException, IOException {
+        return configStoreStorage.readConfigStore();
+    }
+
+    @Override
+    public Optional<ConfigStore> readConfigStore(Path filePath) throws DataConversionException, IOException {
+        logger.fine("Attempting to read data from file: " + filePath);
+        return configStoreStorage.readConfigStore();
+    }
+
+    @Override
+    public void saveConfigStore(ConfigStore configStore) throws IOException {
+        configStoreStorage.saveConfigStore(configStore, configStoreStorage.getConfigStoreStorageFilePath());
+    }
+
+    @Override
+    public void saveConfigStore(ConfigStore configStore, Path filePath) throws IOException {
+        logger.fine("Attempting to write to data file: " + filePath);
+        configStoreStorage.saveConfigStore(configStore, filePath);
+    }
+
+    @Override
+    @Subscribe
+    public void handleConfigStoreChangedEvent(ConfigStoreChangedEvent event) {
+        logger.info(LogsCenter.getEventHandlingLogMessage(event, "Local data changed, saving to file"));
+        try {
+            saveConfigStore(event.data);
         } catch (IOException e) {
             raise(new DataSavingExceptionEvent(e));
         }

--- a/src/main/java/seedu/address/storage/StorageManager.java
+++ b/src/main/java/seedu/address/storage/StorageManager.java
@@ -28,7 +28,8 @@ public class StorageManager extends ComponentManager implements Storage {
     private ConfigStoreStorage configStoreStorage;
 
 
-    public StorageManager(AddressBookStorage addressBookStorage, UserPrefsStorage userPrefsStorage, ConfigStoreStorage configStoreStorage) {
+    public StorageManager(AddressBookStorage addressBookStorage, UserPrefsStorage userPrefsStorage,
+                          ConfigStoreStorage configStoreStorage) {
         super();
         this.addressBookStorage = addressBookStorage;
         this.userPrefsStorage = userPrefsStorage;

--- a/src/main/java/seedu/address/storage/XmlAdaptedConfig.java
+++ b/src/main/java/seedu/address/storage/XmlAdaptedConfig.java
@@ -6,44 +6,42 @@ import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.Config;
 
 /**
- * JAXB-friendly version of the Person.
+ * JAXB-friendly version of the Config.
  */
 public class XmlAdaptedConfig {
 
     public static final String MISSING_FIELD_MESSAGE_FORMAT = "Config %s field is missing!";
 
-    //  @XmlElement(required = true)
-    //  private String name;
     @XmlElement(required = true)
     private byte[] data;
 
 
     /**
-    * Constructs an XmlAdaptedPerson.
+    * Constructs an XmlAdaptedConfig.
     * This is the no-arg constructor that is required by JAXB.
     */
     public XmlAdaptedConfig() {}
 
     /**
-    * Constructs an {@code XmlAdaptedPerson} with the given person details.
+    * Constructs an {@code XmlAdaptedConfig} with the given data.
     */
     public XmlAdaptedConfig(byte[] data) {
         this.data = data;
     }
 
     /**
-    * Converts a given Person into this class for JAXB use.
+    * Converts a given Config into this class for JAXB use.
     *
-    * @param source future changes to this will not affect the created XmlAdaptedPerson
+    * @param source future changes to this will not affect the created XmlAdaptedConfig
     */
     public XmlAdaptedConfig(Config source) {
         data = source.getConfigData();
     }
 
     /**
-    * Converts this jaxb-friendly adapted person object into the model's Person object.
+    * Converts this jaxb-friendly adapted config object into the model's Config object.
     *
-    * @throws IllegalValueException if there were any data constraints violated in the adapted person
+    * @throws IllegalValueException if there were any data constraints violated in the adapted config
     */
     public Config toModelType() throws IllegalValueException {
         if (data == null) {

--- a/src/main/java/seedu/address/storage/XmlAdaptedConfig.java
+++ b/src/main/java/seedu/address/storage/XmlAdaptedConfig.java
@@ -1,87 +1,73 @@
 package seedu.address.storage;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import javax.xml.bind.annotation.XmlElement;
 
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.Config;
-import seedu.address.model.person.Address;
-import seedu.address.model.person.Email;
-import seedu.address.model.person.Name;
-import seedu.address.model.person.Person;
-import seedu.address.model.person.Phone;
-import seedu.address.model.tag.Tag;
 
 /**
  * JAXB-friendly version of the Person.
  */
 public class XmlAdaptedConfig {
 
-  public static final String MISSING_FIELD_MESSAGE_FORMAT = "Config %s field is missing!";
+    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Config %s field is missing!";
 
-//  @XmlElement(required = true)
-//  private String name;
-  @XmlElement(required = true)
-  private byte[] data;
+    //  @XmlElement(required = true)
+    //  private String name;
+    @XmlElement(required = true)
+    private byte[] data;
 
 
-  /**
-   * Constructs an XmlAdaptedPerson.
-   * This is the no-arg constructor that is required by JAXB.
-   */
-  public XmlAdaptedConfig() {}
+    /**
+    * Constructs an XmlAdaptedPerson.
+    * This is the no-arg constructor that is required by JAXB.
+    */
+    public XmlAdaptedConfig() {}
 
-  /**
-   * Constructs an {@code XmlAdaptedPerson} with the given person details.
-   */
-  public XmlAdaptedConfig(byte[] data) {
-//    this.name = name;
-    this.data = data;
-  }
-
-  /**
-   * Converts a given Person into this class for JAXB use.
-   *
-   * @param source future changes to this will not affect the created XmlAdaptedPerson
-   */
-  public XmlAdaptedConfig(Config source) {
-    data = source.getConfigData();
-  }
-
-  /**
-   * Converts this jaxb-friendly adapted person object into the model's Person object.
-   *
-   * @throws IllegalValueException if there were any data constraints violated in the adapted person
-   */
-  public Config toModelType() throws IllegalValueException {
-    if (data == null) {
-      throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, "Username"));
+    /**
+    * Constructs an {@code XmlAdaptedPerson} with the given person details.
+    */
+    public XmlAdaptedConfig(byte[] data) {
+        this.data = data;
     }
 
-    return new Config(data);
-  }
+    /**
+    * Converts a given Person into this class for JAXB use.
+    *
+    * @param source future changes to this will not affect the created XmlAdaptedPerson
+    */
+    public XmlAdaptedConfig(Config source) {
+        data = source.getConfigData();
+    }
 
-//  @Override
-//  public boolean equals(Object other) {
-//    if (other == this) {
-//      return true;
-//    }
-//
-//    if (!(other instanceof XmlAdaptedPerson)) {
-//      return false;
-//    }
-//
-//    XmlAdaptedPerson otherPerson = (XmlAdaptedPerson) other;
-//    return Objects.equals(name, otherPerson.name)
-//            && Objects.equals(phone, otherPerson.phone)
-//            && Objects.equals(email, otherPerson.email)
-//            && Objects.equals(address, otherPerson.address)
-//            && tagged.equals(otherPerson.tagged);
-//  }
+    /**
+    * Converts this jaxb-friendly adapted person object into the model's Person object.
+    *
+    * @throws IllegalValueException if there were any data constraints violated in the adapted person
+    */
+    public Config toModelType() throws IllegalValueException {
+        if (data == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, "Username"));
+        }
+
+        return new Config(data);
+    }
+
+    //  @Override
+    //  public boolean equals(Object other) {
+    //    if (other == this) {
+    //      return true;
+    //    }
+    //
+    //    if (!(other instanceof XmlAdaptedPerson)) {
+    //      return false;
+    //    }
+    //
+    //    XmlAdaptedPerson otherPerson = (XmlAdaptedPerson) other;
+    //    return Objects.equals(name, otherPerson.name)
+    //            && Objects.equals(phone, otherPerson.phone)
+    //            && Objects.equals(email, otherPerson.email)
+    //            && Objects.equals(address, otherPerson.address)
+    //            && tagged.equals(otherPerson.tagged);
+    //  }
 }

--- a/src/main/java/seedu/address/storage/XmlAdaptedConfig.java
+++ b/src/main/java/seedu/address/storage/XmlAdaptedConfig.java
@@ -1,0 +1,87 @@
+package seedu.address.storage;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.xml.bind.annotation.XmlElement;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.Config;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
+import seedu.address.model.tag.Tag;
+
+/**
+ * JAXB-friendly version of the Person.
+ */
+public class XmlAdaptedConfig {
+
+  public static final String MISSING_FIELD_MESSAGE_FORMAT = "Config %s field is missing!";
+
+//  @XmlElement(required = true)
+//  private String name;
+  @XmlElement(required = true)
+  private byte[] data;
+
+
+  /**
+   * Constructs an XmlAdaptedPerson.
+   * This is the no-arg constructor that is required by JAXB.
+   */
+  public XmlAdaptedConfig() {}
+
+  /**
+   * Constructs an {@code XmlAdaptedPerson} with the given person details.
+   */
+  public XmlAdaptedConfig(byte[] data) {
+//    this.name = name;
+    this.data = data;
+  }
+
+  /**
+   * Converts a given Person into this class for JAXB use.
+   *
+   * @param source future changes to this will not affect the created XmlAdaptedPerson
+   */
+  public XmlAdaptedConfig(Config source) {
+    data = source.getConfigData();
+  }
+
+  /**
+   * Converts this jaxb-friendly adapted person object into the model's Person object.
+   *
+   * @throws IllegalValueException if there were any data constraints violated in the adapted person
+   */
+  public Config toModelType() throws IllegalValueException {
+    if (data == null) {
+      throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, "Username"));
+    }
+
+    return new Config(data);
+  }
+
+//  @Override
+//  public boolean equals(Object other) {
+//    if (other == this) {
+//      return true;
+//    }
+//
+//    if (!(other instanceof XmlAdaptedPerson)) {
+//      return false;
+//    }
+//
+//    XmlAdaptedPerson otherPerson = (XmlAdaptedPerson) other;
+//    return Objects.equals(name, otherPerson.name)
+//            && Objects.equals(phone, otherPerson.phone)
+//            && Objects.equals(email, otherPerson.email)
+//            && Objects.equals(address, otherPerson.address)
+//            && tagged.equals(otherPerson.tagged);
+//  }
+}

--- a/src/main/java/seedu/address/storage/XmlConfigStoreStorage.java
+++ b/src/main/java/seedu/address/storage/XmlConfigStoreStorage.java
@@ -16,7 +16,7 @@ import seedu.address.commons.util.FileUtil;
 import seedu.address.model.ConfigStore;
 
 /**
- * A class to access AddressBook data stored as an xml file on the hard disk.
+ * A class to access ConfigStore data stored as an xml file on the hard disk.
  */
 public class XmlConfigStoreStorage implements ConfigStoreStorage {
 

--- a/src/main/java/seedu/address/storage/XmlConfigStoreStorage.java
+++ b/src/main/java/seedu/address/storage/XmlConfigStoreStorage.java
@@ -13,70 +13,67 @@ import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.exceptions.DataConversionException;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.commons.util.FileUtil;
-import seedu.address.model.Config;
 import seedu.address.model.ConfigStore;
-import seedu.address.model.ReadOnlyAddressBook;
 
 /**
  * A class to access AddressBook data stored as an xml file on the hard disk.
  */
 public class XmlConfigStoreStorage implements ConfigStoreStorage {
 
-  private static final Logger logger = LogsCenter.getLogger(XmlConfigStoreStorage.class);
+    private static final Logger logger = LogsCenter.getLogger(XmlConfigStoreStorage.class);
 
-  private Path filePath;
+    private Path filePath;
 
-  public XmlConfigStoreStorage(Path filePath) {
-    this.filePath = filePath;
-  }
+    public XmlConfigStoreStorage(Path filePath) {
+        this.filePath = filePath;
+    }
 
-  public Path getConfigStoreStorageFilePath() {
-    return filePath;
-  }
+    public Path getConfigStoreStorageFilePath() {
+        return filePath;
+    }
 
-  @Override
-  public Optional<ConfigStore> readConfigStore() throws DataConversionException, IOException {
-    return readConfigStore(filePath);
-  }
+    @Override
+    public Optional<ConfigStore> readConfigStore() throws DataConversionException, IOException {
+        return readConfigStore(filePath);
+    }
 
-  /**
-   * Similar to {@link #readConfigStore()}
-   * @param filePath location of the data. Cannot be null
-   * @throws DataConversionException if the file is not in the correct format.
-   */
-  public Optional<ConfigStore> readConfigStore(Path filePath) throws DataConversionException,
+    /**
+    * Similar to {@link #readConfigStore()}
+    * @param filePath location of the data. Cannot be null
+    * @throws DataConversionException if the file is not in the correct format.
+    */
+    public Optional<ConfigStore> readConfigStore(Path filePath) throws DataConversionException,
           FileNotFoundException {
-    requireNonNull(filePath);
+        requireNonNull(filePath);
 
-    if (!Files.exists(filePath)) {
-      logger.info("Config file " + filePath + " not found");
-      return Optional.empty();
+        if (!Files.exists(filePath)) {
+            logger.info("Config file " + filePath + " not found");
+            return Optional.empty();
+        }
+
+        XmlSerializableConfigStore xmlConfigStore = XmlFileStorage.loadConfigStoreDataFromSaveFile(filePath);
+        try {
+            return Optional.of(xmlConfigStore.toModelType());
+        } catch (IllegalValueException ive) {
+            logger.info("Illegal values found in " + filePath + ": " + ive.getMessage());
+            throw new DataConversionException(ive);
+        }
     }
 
-    XmlSerializableConfigStore xmlConfigStore = XmlFileStorage.loadConfigStoreDataFromSaveFile(filePath);
-    try {
-      return Optional.of(xmlConfigStore.toModelType());
-    } catch (IllegalValueException ive) {
-      logger.info("Illegal values found in " + filePath + ": " + ive.getMessage());
-      throw new DataConversionException(ive);
+    @Override
+    public void saveConfigStore(ConfigStore configStore) throws IOException {
+        saveConfigStore(configStore, filePath);
     }
-  }
 
-  @Override
-  public void saveConfigStore(ConfigStore configStore) throws IOException {
-    saveConfigStore(configStore, filePath);
-  }
+    /**
+    * Similar to {@link #saveConfigStore(ConfigStore)}
+    * @param filePath location of the data. Cannot be null
+    */
+    public void saveConfigStore(ConfigStore configStore, Path filePath) throws IOException {
+        requireNonNull(configStore);
+        requireNonNull(filePath);
 
-  /**
-   * Similar to {@link #saveConfigStore(ConfigStore)}
-   * @param filePath location of the data. Cannot be null
-   */
-  public void saveConfigStore(ConfigStore configStore, Path filePath) throws IOException {
-    requireNonNull(configStore);
-    requireNonNull(filePath);
-
-    FileUtil.createIfMissing(filePath);
-    XmlFileStorage.saveDataToFile(filePath, new XmlSerializableConfigStore(configStore));
-  }
-
+        FileUtil.createIfMissing(filePath);
+        XmlFileStorage.saveDataToFile(filePath, new XmlSerializableConfigStore(configStore));
+    }
 }

--- a/src/main/java/seedu/address/storage/XmlConfigStoreStorage.java
+++ b/src/main/java/seedu/address/storage/XmlConfigStoreStorage.java
@@ -1,0 +1,82 @@
+package seedu.address.storage;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.logging.Logger;
+
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.exceptions.DataConversionException;
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.commons.util.FileUtil;
+import seedu.address.model.Config;
+import seedu.address.model.ConfigStore;
+import seedu.address.model.ReadOnlyAddressBook;
+
+/**
+ * A class to access AddressBook data stored as an xml file on the hard disk.
+ */
+public class XmlConfigStoreStorage implements ConfigStoreStorage {
+
+  private static final Logger logger = LogsCenter.getLogger(XmlConfigStoreStorage.class);
+
+  private Path filePath;
+
+  public XmlConfigStoreStorage(Path filePath) {
+    this.filePath = filePath;
+  }
+
+  public Path getConfigStoreStorageFilePath() {
+    return filePath;
+  }
+
+  @Override
+  public Optional<ConfigStore> readConfigStore() throws DataConversionException, IOException {
+    return readConfigStore(filePath);
+  }
+
+  /**
+   * Similar to {@link #readConfigStore()}
+   * @param filePath location of the data. Cannot be null
+   * @throws DataConversionException if the file is not in the correct format.
+   */
+  public Optional<ConfigStore> readConfigStore(Path filePath) throws DataConversionException,
+          FileNotFoundException {
+    requireNonNull(filePath);
+
+    if (!Files.exists(filePath)) {
+      logger.info("Config file " + filePath + " not found");
+      return Optional.empty();
+    }
+
+    XmlSerializableConfigStore xmlConfigStore = XmlFileStorage.loadConfigStoreDataFromSaveFile(filePath);
+    try {
+      return Optional.of(xmlConfigStore.toModelType());
+    } catch (IllegalValueException ive) {
+      logger.info("Illegal values found in " + filePath + ": " + ive.getMessage());
+      throw new DataConversionException(ive);
+    }
+  }
+
+  @Override
+  public void saveConfigStore(ConfigStore configStore) throws IOException {
+    saveConfigStore(configStore, filePath);
+  }
+
+  /**
+   * Similar to {@link #saveConfigStore(ConfigStore)}
+   * @param filePath location of the data. Cannot be null
+   */
+  public void saveConfigStore(ConfigStore configStore, Path filePath) throws IOException {
+    requireNonNull(configStore);
+    requireNonNull(filePath);
+
+    FileUtil.createIfMissing(filePath);
+    XmlFileStorage.saveDataToFile(filePath, new XmlSerializableConfigStore(configStore));
+  }
+
+}

--- a/src/main/java/seedu/address/storage/XmlFileStorage.java
+++ b/src/main/java/seedu/address/storage/XmlFileStorage.java
@@ -2,7 +2,6 @@ package seedu.address.storage;
 
 import java.io.FileNotFoundException;
 import java.nio.file.Path;
-import java.util.stream.Collectors;
 
 import javax.xml.bind.JAXBException;
 
@@ -26,6 +25,17 @@ public class XmlFileStorage {
     }
 
     /**
+     * Saves the given credential store data to the specified file.
+     */
+    public static void saveDataToFile(Path file, XmlSerializableConfigStore configStore) throws FileNotFoundException {
+        try {
+            XmlUtil.saveDataToFile(file, configStore);
+        } catch (JAXBException e) {
+            throw new AssertionError("Unexpected exception " + e.getMessage(), e);
+        }
+    }
+
+    /**
      * Returns address book in the file or an empty address book
      */
     public static XmlSerializableAddressBook loadDataFromSaveFile(Path file) throws DataConversionException,
@@ -34,17 +44,6 @@ public class XmlFileStorage {
             return XmlUtil.getDataFromFile(file, XmlSerializableAddressBook.class);
         } catch (JAXBException e) {
             throw new DataConversionException(e);
-        }
-    }
-
-    /**
-     * Saves the given credential store data to the specified file.
-     */
-    public static void saveDataToFile(Path file, XmlSerializableConfigStore configStore) throws FileNotFoundException {
-        try {
-            XmlUtil.saveDataToFile(file, configStore);
-        } catch (JAXBException e) {
-            throw new AssertionError("Unexpected exception " + e.getMessage(), e);
         }
     }
 

--- a/src/main/java/seedu/address/storage/XmlFileStorage.java
+++ b/src/main/java/seedu/address/storage/XmlFileStorage.java
@@ -2,6 +2,7 @@ package seedu.address.storage;
 
 import java.io.FileNotFoundException;
 import java.nio.file.Path;
+import java.util.stream.Collectors;
 
 import javax.xml.bind.JAXBException;
 
@@ -35,5 +36,30 @@ public class XmlFileStorage {
             throw new DataConversionException(e);
         }
     }
+
+    /**
+     * Saves the given credential store data to the specified file.
+     */
+    public static void saveDataToFile(Path file, XmlSerializableConfigStore configStore) throws FileNotFoundException {
+        try {
+            XmlUtil.saveDataToFile(file, configStore);
+        } catch (JAXBException e) {
+            throw new AssertionError("Unexpected exception " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Returns CredentialStore in the file or an empty usercredentials
+     */
+    public static XmlSerializableConfigStore loadConfigStoreDataFromSaveFile(Path file) throws DataConversionException,
+
+            FileNotFoundException {
+        try {
+            return XmlUtil.getDataFromFile(file, XmlSerializableConfigStore.class);
+        } catch (JAXBException e) {
+            throw new DataConversionException(e);
+        }
+    }
+
 
 }

--- a/src/main/java/seedu/address/storage/XmlSerializableConfigStore.java
+++ b/src/main/java/seedu/address/storage/XmlSerializableConfigStore.java
@@ -1,0 +1,72 @@
+package seedu.address.storage;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.oracle.tools.packager.IOUtils;
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Config;
+import seedu.address.model.ConfigStore;
+import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.person.Person;
+
+/**
+ * An Immutable AddressBook that is serializable to XML format
+ */
+@XmlRootElement(name = "configstore")
+public class XmlSerializableConfigStore {
+
+//  public static final String MESSAGE_DUPLICATE_PERSON = "Persons list contains duplicate person(s).";
+
+  @XmlElement
+  private List<XmlAdaptedConfig> configDatas;
+
+  /**
+   * Creates an empty XmlSerializableAddressBook.
+   * This empty constructor is required for marshalling.
+   */
+  public XmlSerializableConfigStore() {
+    configDatas = new ArrayList<>();
+  }
+
+  /**
+   * Conversion
+   */
+  public XmlSerializableConfigStore(ConfigStore src) {
+    this();
+    XmlAdaptedConfig adaptedConfig = new XmlAdaptedConfig(src.getConfigData());
+    configDatas.add(adaptedConfig);
+  }
+
+  /**
+   * Converts this addressbook into the model's {@code AddressBook} object.
+   *l
+   * @throws IllegalValueException if there were any data constraints violated or duplicates in the
+   * {@code XmlAdaptedPerson}.
+   */
+  public ConfigStore toModelType() throws IllegalValueException {
+    ConfigStore configStore = new ConfigStore();
+    for (XmlAdaptedConfig adaptedConfig : configDatas) {
+      Config config = adaptedConfig.toModelType();
+      configStore.addConfigData(config);
+    }
+    return configStore;
+  }
+
+//  @Override
+//  public boolean equals(Object other) {
+//    if (other == this) {
+//      return true;
+//    }
+//
+//    if (!(other instanceof XmlSerializableConfigStore)) {
+//      return false;
+//    }
+//    return persons.equals(((XmlSerializableConfigStore) other).persons);
+//  }
+}

--- a/src/main/java/seedu/address/storage/XmlSerializableConfigStore.java
+++ b/src/main/java/seedu/address/storage/XmlSerializableConfigStore.java
@@ -11,7 +11,7 @@ import seedu.address.model.Config;
 import seedu.address.model.ConfigStore;
 
 /**
- * An Immutable AddressBook that is serializable to XML format
+ * An Immutable ConfigStore that is serializable to XML format
  */
 @XmlRootElement(name = "configstore")
 public class XmlSerializableConfigStore {
@@ -20,7 +20,7 @@ public class XmlSerializableConfigStore {
     private List<XmlAdaptedConfig> configDatas;
 
     /**
-    * Creates an empty XmlSerializableAddressBook.
+    * Creates an empty XmlSerializableConfigStore.
     * This empty constructor is required for marshalling.
     */
     public XmlSerializableConfigStore() {
@@ -37,10 +37,10 @@ public class XmlSerializableConfigStore {
     }
 
     /**
-    * Converts this addressbook into the model's {@code AddressBook} object.
+    * Converts this configstore into the model's {@code ConfigStore} object.
     *l
     * @throws IllegalValueException if there were any data constraints violated or duplicates in the
-    * {@code XmlAdaptedPerson}.
+    * {@code XmlAdaptedConfig}.
     */
     public ConfigStore toModelType() throws IllegalValueException {
         ConfigStore configStore = new ConfigStore();

--- a/src/main/java/seedu/address/storage/XmlSerializableConfigStore.java
+++ b/src/main/java/seedu/address/storage/XmlSerializableConfigStore.java
@@ -2,18 +2,13 @@ package seedu.address.storage;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
-import com.oracle.tools.packager.IOUtils;
 import seedu.address.commons.exceptions.IllegalValueException;
-import seedu.address.model.AddressBook;
 import seedu.address.model.Config;
 import seedu.address.model.ConfigStore;
-import seedu.address.model.ReadOnlyAddressBook;
-import seedu.address.model.person.Person;
 
 /**
  * An Immutable AddressBook that is serializable to XML format
@@ -21,52 +16,38 @@ import seedu.address.model.person.Person;
 @XmlRootElement(name = "configstore")
 public class XmlSerializableConfigStore {
 
-//  public static final String MESSAGE_DUPLICATE_PERSON = "Persons list contains duplicate person(s).";
+    @XmlElement
+    private List<XmlAdaptedConfig> configDatas;
 
-  @XmlElement
-  private List<XmlAdaptedConfig> configDatas;
-
-  /**
-   * Creates an empty XmlSerializableAddressBook.
-   * This empty constructor is required for marshalling.
-   */
-  public XmlSerializableConfigStore() {
-    configDatas = new ArrayList<>();
-  }
-
-  /**
-   * Conversion
-   */
-  public XmlSerializableConfigStore(ConfigStore src) {
-    this();
-    XmlAdaptedConfig adaptedConfig = new XmlAdaptedConfig(src.getConfigData());
-    configDatas.add(adaptedConfig);
-  }
-
-  /**
-   * Converts this addressbook into the model's {@code AddressBook} object.
-   *l
-   * @throws IllegalValueException if there were any data constraints violated or duplicates in the
-   * {@code XmlAdaptedPerson}.
-   */
-  public ConfigStore toModelType() throws IllegalValueException {
-    ConfigStore configStore = new ConfigStore();
-    for (XmlAdaptedConfig adaptedConfig : configDatas) {
-      Config config = adaptedConfig.toModelType();
-      configStore.addConfigData(config);
+    /**
+    * Creates an empty XmlSerializableAddressBook.
+    * This empty constructor is required for marshalling.
+    */
+    public XmlSerializableConfigStore() {
+        configDatas = new ArrayList<>();
     }
-    return configStore;
-  }
 
-//  @Override
-//  public boolean equals(Object other) {
-//    if (other == this) {
-//      return true;
-//    }
-//
-//    if (!(other instanceof XmlSerializableConfigStore)) {
-//      return false;
-//    }
-//    return persons.equals(((XmlSerializableConfigStore) other).persons);
-//  }
+    /**
+    * Conversion
+    */
+    public XmlSerializableConfigStore(ConfigStore src) {
+        this();
+        XmlAdaptedConfig adaptedConfig = new XmlAdaptedConfig(src.getConfigData());
+        configDatas.add(adaptedConfig);
+    }
+
+    /**
+    * Converts this addressbook into the model's {@code AddressBook} object.
+    *l
+    * @throws IllegalValueException if there were any data constraints violated or duplicates in the
+    * {@code XmlAdaptedPerson}.
+    */
+    public ConfigStore toModelType() throws IllegalValueException {
+        ConfigStore configStore = new ConfigStore();
+        for (XmlAdaptedConfig adaptedConfig : configDatas) {
+            Config config = adaptedConfig.toModelType();
+            configStore.addConfigData(config);
+        }
+        return configStore;
+    }
 }

--- a/src/test/java/seedu/address/TestApp.java
+++ b/src/test/java/seedu/address/TestApp.java
@@ -12,6 +12,7 @@ import seedu.address.commons.exceptions.DataConversionException;
 import seedu.address.commons.util.FileUtil;
 import seedu.address.commons.util.XmlUtil;
 import seedu.address.model.AddressBook;
+import seedu.address.model.ConfigStore;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.ReadOnlyAddressBook;
@@ -92,7 +93,7 @@ public class TestApp extends MainApp {
      * Returns a defensive copy of the model.
      */
     public Model getModel() {
-        Model copy = new ModelManager((model.getAddressBook()), new UserPrefs());
+        Model copy = new ModelManager((model.getAddressBook()), new UserPrefs(), new ConfigStore());
         ModelHelper.setFilteredList(copy, model.getFilteredPersonList());
         return copy;
     }

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -13,6 +13,7 @@ import seedu.address.logic.commands.HistoryCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.ConfigStore;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -82,7 +83,7 @@ public class LogicManagerTest {
      * @see #assertCommandBehavior(Class, String, String, Model)
      */
     private void assertCommandFailure(String inputCommand, Class<?> expectedException, String expectedMessage) {
-        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs(), new ConfigStore());
         assertCommandBehavior(expectedException, inputCommand, expectedMessage, expectedModel);
     }
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -8,6 +8,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import seedu.address.logic.CommandHistory;
+import seedu.address.model.ConfigStore;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -24,14 +25,14 @@ public class AddCommandIntegrationTest {
 
     @Before
     public void setUp() {
-        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new ConfigStore());
     }
 
     @Test
     public void execute_newPerson_success() {
         Person validPerson = new PersonBuilder().build();
 
-        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs(), new ConfigStore());
         expectedModel.addPerson(validPerson);
         expectedModel.commitAddressBook();
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -17,6 +17,7 @@ import javafx.collections.ObservableList;
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
+import seedu.address.model.Config;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Person;
@@ -150,6 +151,11 @@ public class AddCommandTest {
 
         @Override
         public void commitAddressBook() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void saveConfigFile(Config c) {
             throw new AssertionError("This method should not be called.");
         }
     }

--- a/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 
 import seedu.address.logic.CommandHistory;
 import seedu.address.model.AddressBook;
+import seedu.address.model.ConfigStore;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -26,8 +27,8 @@ public class ClearCommandTest {
 
     @Test
     public void execute_nonEmptyAddressBook_success() {
-        Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-        Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new ConfigStore());
+        Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new ConfigStore());
         expectedModel.resetData(new AddressBook());
         expectedModel.commitAddressBook();
 

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.CommandHistory;
+import seedu.address.model.ConfigStore;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -26,7 +27,7 @@ import seedu.address.model.person.Person;
  */
 public class DeleteCommandTest {
 
-    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new ConfigStore());
     private CommandHistory commandHistory = new CommandHistory();
 
     @Test
@@ -36,7 +37,7 @@ public class DeleteCommandTest {
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete);
 
-        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs(), new ConfigStore());
         expectedModel.deletePerson(personToDelete);
         expectedModel.commitAddressBook();
 
@@ -60,7 +61,7 @@ public class DeleteCommandTest {
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete);
 
-        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs(), new ConfigStore());
         expectedModel.deletePerson(personToDelete);
         expectedModel.commitAddressBook();
         showNoPerson(expectedModel);
@@ -85,7 +86,7 @@ public class DeleteCommandTest {
     public void executeUndoRedo_validIndexUnfilteredList_success() throws Exception {
         Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
-        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs(), new ConfigStore());
         expectedModel.deletePerson(personToDelete);
         expectedModel.commitAddressBook();
 
@@ -124,7 +125,7 @@ public class DeleteCommandTest {
     @Test
     public void executeUndoRedo_validIndexFilteredList_samePersonDeleted() throws Exception {
         DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
-        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs(), new ConfigStore());
 
         showPersonAtIndex(model, INDEX_SECOND_PERSON);
         Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -46,7 +46,8 @@ public class EditCommandTest {
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
 
-        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs(), new ConfigStore());
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs(),
+                new ConfigStore());
         expectedModel.updatePerson(model.getFilteredPersonList().get(0), editedPerson);
         expectedModel.commitAddressBook();
 
@@ -68,7 +69,8 @@ public class EditCommandTest {
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
 
-        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs(), new ConfigStore());
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs(),
+                new ConfigStore());
         expectedModel.updatePerson(lastPerson, editedPerson);
         expectedModel.commitAddressBook();
 
@@ -82,7 +84,8 @@ public class EditCommandTest {
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
 
-        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs(), new ConfigStore());
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs(),
+                new ConfigStore());
         expectedModel.commitAddressBook();
 
         assertCommandSuccess(editCommand, model, commandHistory, expectedMessage, expectedModel);
@@ -99,7 +102,8 @@ public class EditCommandTest {
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
 
-        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs(), new ConfigStore());
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs(),
+                new ConfigStore());
         expectedModel.updatePerson(model.getFilteredPersonList().get(0), editedPerson);
         expectedModel.commitAddressBook();
 
@@ -159,7 +163,8 @@ public class EditCommandTest {
         Person personToEdit = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(editedPerson).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
-        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs(), new ConfigStore());
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs(),
+                new ConfigStore());
         expectedModel.updatePerson(personToEdit, editedPerson);
         expectedModel.commitAddressBook();
 
@@ -201,7 +206,8 @@ public class EditCommandTest {
         Person editedPerson = new PersonBuilder().build();
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(editedPerson).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
-        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs(), new ConfigStore());
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs(),
+                new ConfigStore());
 
         showPersonAtIndex(model, INDEX_SECOND_PERSON);
         Person personToEdit = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -22,6 +22,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.model.AddressBook;
+import seedu.address.model.ConfigStore;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -34,7 +35,7 @@ import seedu.address.testutil.PersonBuilder;
  */
 public class EditCommandTest {
 
-    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new ConfigStore());
     private CommandHistory commandHistory = new CommandHistory();
 
     @Test
@@ -45,7 +46,7 @@ public class EditCommandTest {
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
 
-        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs(), new ConfigStore());
         expectedModel.updatePerson(model.getFilteredPersonList().get(0), editedPerson);
         expectedModel.commitAddressBook();
 
@@ -67,7 +68,7 @@ public class EditCommandTest {
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
 
-        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs(), new ConfigStore());
         expectedModel.updatePerson(lastPerson, editedPerson);
         expectedModel.commitAddressBook();
 
@@ -81,7 +82,7 @@ public class EditCommandTest {
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
 
-        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs(), new ConfigStore());
         expectedModel.commitAddressBook();
 
         assertCommandSuccess(editCommand, model, commandHistory, expectedMessage, expectedModel);
@@ -98,7 +99,7 @@ public class EditCommandTest {
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
 
-        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs(), new ConfigStore());
         expectedModel.updatePerson(model.getFilteredPersonList().get(0), editedPerson);
         expectedModel.commitAddressBook();
 
@@ -158,7 +159,7 @@ public class EditCommandTest {
         Person personToEdit = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(editedPerson).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
-        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs(), new ConfigStore());
         expectedModel.updatePerson(personToEdit, editedPerson);
         expectedModel.commitAddressBook();
 
@@ -200,7 +201,7 @@ public class EditCommandTest {
         Person editedPerson = new PersonBuilder().build();
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(editedPerson).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
-        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs(), new ConfigStore());
 
         showPersonAtIndex(model, INDEX_SECOND_PERSON);
         Person personToEdit = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -16,6 +16,7 @@ import java.util.Collections;
 import org.junit.Test;
 
 import seedu.address.logic.CommandHistory;
+import seedu.address.model.ConfigStore;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -25,8 +26,8 @@ import seedu.address.model.person.NameContainsKeywordsPredicate;
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
  */
 public class FindCommandTest {
-    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new ConfigStore());
+    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new ConfigStore());
     private CommandHistory commandHistory = new CommandHistory();
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -9,6 +9,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import seedu.address.logic.CommandHistory;
+import seedu.address.model.ConfigStore;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -24,8 +25,8 @@ public class ListCommandTest {
 
     @Before
     public void setUp() {
-        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-        expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new ConfigStore());
+        expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs(), new ConfigStore());
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/RedoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RedoCommandTest.java
@@ -9,14 +9,15 @@ import org.junit.Before;
 import org.junit.Test;
 
 import seedu.address.logic.CommandHistory;
+import seedu.address.model.ConfigStore;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 
 public class RedoCommandTest {
 
-    private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-    private final Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new ConfigStore());
+    private final Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new ConfigStore());
     private final CommandHistory commandHistory = new CommandHistory();
 
     @Before

--- a/src/test/java/seedu/address/logic/commands/SaveCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SaveCommandTest.java
@@ -1,0 +1,50 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import seedu.address.logic.CommandHistory;
+import seedu.address.model.Config;
+import seedu.address.testutil.ConfigBuilder;
+
+public class SaveCommandTest {
+
+    private static final CommandHistory EMPTY_COMMAND_HISTORY = new CommandHistory();
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private CommandHistory commandHistory = new CommandHistory();
+
+    @Test
+    public void constructor_nullPerson_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        new SaveCommand(null);
+    }
+
+    @Test
+    public void equals() {
+        Config config = new ConfigBuilder().withData("hello".getBytes()).build();
+        SaveCommand configSaveCommand = new SaveCommand(config);
+
+        // same object -> returns true
+        assertTrue(configSaveCommand.equals(configSaveCommand));
+
+        // same values -> returns true
+        SaveCommand addConfigSaveCommandCopy = new SaveCommand(config);
+        assertTrue(addConfigSaveCommandCopy.equals(addConfigSaveCommandCopy));
+
+        // different types -> returns false
+        assertFalse(configSaveCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(configSaveCommand.equals(null));
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/SaveCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SaveCommandTest.java
@@ -1,7 +1,5 @@
 package seedu.address.logic.commands;
 
-import static java.util.Objects.requireNonNull;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 

--- a/src/test/java/seedu/address/logic/commands/SaveCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SaveCommandTest.java
@@ -30,7 +30,7 @@ public class SaveCommandTest {
 
     @Test
     public void equals() {
-        Config config = new ConfigBuilder().withData("hello".getBytes()).build();
+        Config config = new ConfigBuilder().withData("Some data".getBytes()).build();
         SaveCommand configSaveCommand = new SaveCommand(config);
 
         // same object -> returns true

--- a/src/test/java/seedu/address/logic/commands/SaveIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/SaveIntegrationTest.java
@@ -1,0 +1,42 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import seedu.address.logic.CommandHistory;
+import seedu.address.model.Config;
+import seedu.address.model.ConfigStore;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.testutil.ConfigBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code SaveCommand}.
+ */
+public class SaveIntegrationTest {
+
+    private Model model;
+    private CommandHistory commandHistory = new CommandHistory();
+
+    @Before
+    public void setUp() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new ConfigStore());
+    }
+
+    @Test
+    public void execute_saveConfig_success() {
+        Config validConfig = new ConfigBuilder().build();
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs(), new ConfigStore());
+        expectedModel.saveConfigFile(validConfig);
+        expectedModel.commitAddressBook();
+
+        assertCommandSuccess(new SaveCommand(validConfig), model, commandHistory,
+                String.format(SaveCommand.MESSAGE_SUCCESS, validConfig), expectedModel);
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/SelectCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SelectCommandTest.java
@@ -18,6 +18,7 @@ import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.events.ui.JumpToListRequestEvent;
 import seedu.address.logic.CommandHistory;
+import seedu.address.model.ConfigStore;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -30,8 +31,8 @@ public class SelectCommandTest {
     @Rule
     public final EventsCollectorRule eventsCollectorRule = new EventsCollectorRule();
 
-    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new ConfigStore());
+    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new ConfigStore());
     private CommandHistory commandHistory = new CommandHistory();
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
@@ -9,14 +9,15 @@ import org.junit.Before;
 import org.junit.Test;
 
 import seedu.address.logic.CommandHistory;
+import seedu.address.model.ConfigStore;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 
 public class UndoCommandTest {
 
-    private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-    private final Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new ConfigStore());
+    private final Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new ConfigStore());
     private final CommandHistory commandHistory = new CommandHistory();
 
     @Before

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -51,9 +51,12 @@ public class ModelManagerTest {
         AddressBook differentAddressBook = new AddressBook();
         UserPrefs userPrefs = new UserPrefs();
 
+        ConfigStore configStore = new ConfigStore();
+
+
         // same values -> returns true
-        modelManager = new ModelManager(addressBook, userPrefs);
-        ModelManager modelManagerCopy = new ModelManager(addressBook, userPrefs);
+        modelManager = new ModelManager(addressBook, userPrefs, configStore);
+        ModelManager modelManagerCopy = new ModelManager(addressBook, userPrefs, configStore);
         assertTrue(modelManager.equals(modelManagerCopy));
 
         // same object -> returns true
@@ -66,12 +69,12 @@ public class ModelManagerTest {
         assertFalse(modelManager.equals(5));
 
         // different addressBook -> returns false
-        assertFalse(modelManager.equals(new ModelManager(differentAddressBook, userPrefs)));
+        assertFalse(modelManager.equals(new ModelManager(differentAddressBook, userPrefs, configStore)));
 
         // different filteredList -> returns false
         String[] keywords = ALICE.getName().fullName.split("\\s+");
         modelManager.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(keywords)));
-        assertFalse(modelManager.equals(new ModelManager(addressBook, userPrefs)));
+        assertFalse(modelManager.equals(new ModelManager(addressBook, userPrefs, configStore)));
 
         // resets modelManager to initial state for upcoming tests
         modelManager.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
@@ -79,6 +82,6 @@ public class ModelManagerTest {
         // different userPrefs -> returns true
         UserPrefs differentUserPrefs = new UserPrefs();
         differentUserPrefs.setAddressBookFilePath(Paths.get("differentFilePath"));
-        assertTrue(modelManager.equals(new ModelManager(addressBook, differentUserPrefs)));
+        assertTrue(modelManager.equals(new ModelManager(addressBook, differentUserPrefs, configStore)));
     }
 }

--- a/src/test/java/seedu/address/storage/StorageManagerTest.java
+++ b/src/test/java/seedu/address/storage/StorageManagerTest.java
@@ -34,7 +34,8 @@ public class StorageManagerTest {
     public void setUp() {
         XmlAddressBookStorage addressBookStorage = new XmlAddressBookStorage(getTempFilePath("ab"));
         JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(getTempFilePath("prefs"));
-        storageManager = new StorageManager(addressBookStorage, userPrefsStorage);
+        XmlConfigStoreStorage configStoreStorage = new XmlConfigStoreStorage(getTempFilePath("cd"));
+        storageManager = new StorageManager(addressBookStorage, userPrefsStorage, configStoreStorage);
     }
 
     private Path getTempFilePath(String fileName) {
@@ -78,7 +79,7 @@ public class StorageManagerTest {
     public void handleAddressBookChangedEvent_exceptionThrown_eventRaised() {
         // Create a StorageManager while injecting a stub that  throws an exception when the save method is called
         Storage storage = new StorageManager(new XmlAddressBookStorageExceptionThrowingStub(Paths.get("dummy")),
-                                             new JsonUserPrefsStorage(Paths.get("dummy")));
+                                             new JsonUserPrefsStorage(Paths.get("dummy")), new XmlConfigStoreStorage(Paths.get("dummy")));
         storage.handleAddressBookChangedEvent(new AddressBookChangedEvent(new AddressBook()));
         assertTrue(eventsCollectorRule.eventsCollector.getMostRecent() instanceof DataSavingExceptionEvent);
     }

--- a/src/test/java/seedu/address/storage/StorageManagerTest.java
+++ b/src/test/java/seedu/address/storage/StorageManagerTest.java
@@ -79,7 +79,7 @@ public class StorageManagerTest {
     public void handleAddressBookChangedEvent_exceptionThrown_eventRaised() {
         // Create a StorageManager while injecting a stub that  throws an exception when the save method is called
         Storage storage = new StorageManager(new XmlAddressBookStorageExceptionThrowingStub(Paths.get("dummy")),
-                                             new JsonUserPrefsStorage(Paths.get("dummy")), new XmlConfigStoreStorage(Paths.get("dummy")));
+                new JsonUserPrefsStorage(Paths.get("dummy")), new XmlConfigStoreStorage(Paths.get("dummy")));
         storage.handleAddressBookChangedEvent(new AddressBookChangedEvent(new AddressBook()));
         assertTrue(eventsCollectorRule.eventsCollector.getMostRecent() instanceof DataSavingExceptionEvent);
     }

--- a/src/test/java/seedu/address/testutil/ConfigBuilder.java
+++ b/src/test/java/seedu/address/testutil/ConfigBuilder.java
@@ -33,7 +33,7 @@ public class ConfigBuilder {
     }
 
     /**
-     * Sets the {@code Name} of the {@code Person} that we are building.
+     * Sets the {@code data} of the {@code Config} that we are building.
      */
     public ConfigBuilder withData(byte[] data) {
         this.data = data;

--- a/src/test/java/seedu/address/testutil/ConfigBuilder.java
+++ b/src/test/java/seedu/address/testutil/ConfigBuilder.java
@@ -1,0 +1,47 @@
+package seedu.address.testutil;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import seedu.address.model.Config;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
+import seedu.address.model.tag.Tag;
+import seedu.address.model.util.SampleDataUtil;
+
+/**
+ * A utility class to help with building Config objects.
+ */
+public class ConfigBuilder {
+
+    public static final String DEFAULT_DATA = "Some data";
+
+    private byte[] data;
+
+    public ConfigBuilder() {
+        this.data = DEFAULT_DATA.getBytes();
+    }
+
+    /**
+     * Initializes the ConfigBuilder with the data of {@code configToStore}.
+     */
+    public ConfigBuilder(Config configToStore) {
+        this.data = configToStore.getConfigData();
+    }
+
+    /**
+     * Sets the {@code Name} of the {@code Person} that we are building.
+     */
+    public ConfigBuilder withData(byte[] data) {
+        this.data = data;
+        return this;
+    }
+
+    public Config build() {
+        return new Config(data);
+    }
+
+}

--- a/src/test/java/seedu/address/testutil/ConfigBuilder.java
+++ b/src/test/java/seedu/address/testutil/ConfigBuilder.java
@@ -1,16 +1,6 @@
 package seedu.address.testutil;
 
-import java.util.HashSet;
-import java.util.Set;
-
 import seedu.address.model.Config;
-import seedu.address.model.person.Address;
-import seedu.address.model.person.Email;
-import seedu.address.model.person.Name;
-import seedu.address.model.person.Person;
-import seedu.address.model.person.Phone;
-import seedu.address.model.tag.Tag;
-import seedu.address.model.util.SampleDataUtil;
 
 /**
  * A utility class to help with building Config objects.

--- a/src/test/java/seedu/address/testutil/TypicalConfig.java
+++ b/src/test/java/seedu/address/testutil/TypicalConfig.java
@@ -8,7 +8,7 @@ import seedu.address.model.ConfigStore;
  */
 public class TypicalConfig {
 
-    public static final Config data = new ConfigBuilder().withData("data1".getBytes()).build();
+    public static final Config DATA = new ConfigBuilder().withData("data1".getBytes()).build();
 
     private TypicalConfig() {} // prevents instantiation
 
@@ -20,6 +20,6 @@ public class TypicalConfig {
     }
 
     public static Config getTypicalConfig() {
-        return new Config(data.getConfigData());
+        return new Config(DATA.getConfigData());
     }
 }

--- a/src/test/java/seedu/address/testutil/TypicalConfig.java
+++ b/src/test/java/seedu/address/testutil/TypicalConfig.java
@@ -1,0 +1,27 @@
+package seedu.address.testutil;
+
+import seedu.address.model.Config;
+import seedu.address.model.ConfigStore;
+
+/**
+ * A utility class containing a {@code Config} object to be used in tests.
+ */
+public class TypicalConfig {
+
+    public static final Config data = new ConfigBuilder().withData("data1".getBytes()).build();
+
+    private TypicalConfig() {} // prevents instantiation
+
+    /**
+     * Returns an {@code ConfigStore} with all the typical Config.
+     */
+    public static ConfigStore getTypicalConfigStore() {
+        ConfigStore cs = new ConfigStore();
+        cs = getTypicalConfigStore();
+        return cs;
+    }
+
+    public static Config getTypicalConfig() {
+        return new Config(data.getConfigData());
+    }
+}

--- a/src/test/java/seedu/address/testutil/TypicalConfig.java
+++ b/src/test/java/seedu/address/testutil/TypicalConfig.java
@@ -16,9 +16,7 @@ public class TypicalConfig {
      * Returns an {@code ConfigStore} with all the typical Config.
      */
     public static ConfigStore getTypicalConfigStore() {
-        ConfigStore cs = new ConfigStore();
-        cs = getTypicalConfigStore();
-        return cs;
+        return getTypicalConfigStore();
     }
 
     public static Config getTypicalConfig() {


### PR DESCRIPTION
This pull request for v1.1 Summary of Milestone work. In this PR, a save command has been added in. The SaveCommand allows users to save module configuration within the application.

Model
A ConfigStore and a Config model have been included to encapsulate all relevant data pertaining to the module Config of an individual. Config holds the byte array in preparation for the encryption feature.

Logic
SaveCommand has been added. Currently, executing the command with the relevant data fields will create a new Config with hardcoded values. In addition, a message would be displayed indicating to the user that the configuration has been saved.

Storage
Additional classes, namely XmlSerializableConfigStore and XmlAdaptedConfig have been included to support the reading and writing of data to an XML data file.

Testing
SaveCommandTest and SaveIntegrationTest have been included for test cases.