### PR TITLE
User Account Management: Logout Command

### DIFF
--- a/src/main/java/seedu/modsuni/commons/events/ui/UserTabChangedEvent.java
+++ b/src/main/java/seedu/modsuni/commons/events/ui/UserTabChangedEvent.java
@@ -1,6 +1,7 @@
 package seedu.modsuni.commons.events.ui;
 
 import seedu.modsuni.commons.events.BaseEvent;
+
 import seedu.modsuni.model.user.User;
 
 /**

--- a/src/main/java/seedu/modsuni/commons/events/ui/UserTabLogoutEvent.java
+++ b/src/main/java/seedu/modsuni/commons/events/ui/UserTabLogoutEvent.java
@@ -1,0 +1,14 @@
+package seedu.modsuni.commons.events.ui;
+
+
+import seedu.modsuni.commons.events.BaseEvent;
+
+/**
+ * An event indicating a user has logged out.
+ */
+public class UserTabLogoutEvent extends BaseEvent {
+    @Override
+    public String toString() {
+        return getClass().getSimpleName();
+    }
+}

--- a/src/main/java/seedu/modsuni/commons/events/ui/UserTabLogoutEvent.java
+++ b/src/main/java/seedu/modsuni/commons/events/ui/UserTabLogoutEvent.java
@@ -1,6 +1,5 @@
 package seedu.modsuni.commons.events.ui;
 
-
 import seedu.modsuni.commons.events.BaseEvent;
 
 /**

--- a/src/main/java/seedu/modsuni/logic/CommandHistory.java
+++ b/src/main/java/seedu/modsuni/logic/CommandHistory.java
@@ -34,6 +34,13 @@ public class CommandHistory {
         return new LinkedList<>(userInputHistory);
     }
 
+    /**
+     * Resets the {@code userInputHistory}.
+     */
+    public void resetHistory() {
+        userInputHistory = new LinkedList<>();
+    }
+
     @Override
     public boolean equals(Object obj) {
         // short circuit if same object

--- a/src/main/java/seedu/modsuni/logic/commands/LogoutCommand.java
+++ b/src/main/java/seedu/modsuni/logic/commands/LogoutCommand.java
@@ -1,0 +1,25 @@
+package seedu.modsuni.logic.commands;
+
+import seedu.modsuni.logic.CommandHistory;
+import seedu.modsuni.logic.commands.exceptions.CommandException;
+import seedu.modsuni.model.Model;
+
+/**
+ * Command to allow Users to logout and reset the application
+ * data.
+ */
+public class LogoutCommand extends Command{
+
+    public static final String COMMAND_WORD = "logout";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Logout from "
+        + "the account of the current user. All user related data would be "
+        + "reset.\n";
+
+    public static final String MESSAGE_SUCCESS = "Logout Successfully!";
+
+    @Override
+    public CommandResult execute(Model model, CommandHistory history) throws CommandException {
+        return null;
+    }
+}

--- a/src/main/java/seedu/modsuni/logic/commands/LogoutCommand.java
+++ b/src/main/java/seedu/modsuni/logic/commands/LogoutCommand.java
@@ -1,5 +1,7 @@
 package seedu.modsuni.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+
 import seedu.modsuni.logic.CommandHistory;
 import seedu.modsuni.logic.commands.exceptions.CommandException;
 import seedu.modsuni.model.Model;
@@ -8,7 +10,7 @@ import seedu.modsuni.model.Model;
  * Command to allow Users to logout and reset the application
  * data.
  */
-public class LogoutCommand extends Command{
+public class LogoutCommand extends Command {
 
     public static final String COMMAND_WORD = "logout";
 
@@ -18,8 +20,15 @@ public class LogoutCommand extends Command{
 
     public static final String MESSAGE_SUCCESS = "Logout Successfully!";
 
+    public static final String MESSAGE_NOT_LOGGED_IN = "You are not logged in.";
+
     @Override
     public CommandResult execute(Model model, CommandHistory history) throws CommandException {
-        return null;
+        requireNonNull(model);
+        if (model.getCurrentUser() == null) {
+            throw new CommandException(MESSAGE_NOT_LOGGED_IN);
+        }
+        model.resetCurrentUser();
+        return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/modsuni/logic/commands/LogoutCommand.java
+++ b/src/main/java/seedu/modsuni/logic/commands/LogoutCommand.java
@@ -31,6 +31,7 @@ public class LogoutCommand extends Command {
             throw new CommandException(MESSAGE_NOT_LOGGED_IN);
         }
         model.resetCurrentUser();
+        history.resetHistory();
         EventsCenter.getInstance().post(new UserTabLogoutEvent());
         return new CommandResult(MESSAGE_SUCCESS);
     }

--- a/src/main/java/seedu/modsuni/logic/commands/LogoutCommand.java
+++ b/src/main/java/seedu/modsuni/logic/commands/LogoutCommand.java
@@ -2,6 +2,8 @@ package seedu.modsuni.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import seedu.modsuni.commons.core.EventsCenter;
+import seedu.modsuni.commons.events.ui.UserTabLogoutEvent;
 import seedu.modsuni.logic.CommandHistory;
 import seedu.modsuni.logic.commands.exceptions.CommandException;
 import seedu.modsuni.model.Model;
@@ -29,6 +31,7 @@ public class LogoutCommand extends Command {
             throw new CommandException(MESSAGE_NOT_LOGGED_IN);
         }
         model.resetCurrentUser();
+        EventsCenter.getInstance().post(new UserTabLogoutEvent());
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/modsuni/logic/parser/ModsUniParser.java
+++ b/src/main/java/seedu/modsuni/logic/parser/ModsUniParser.java
@@ -24,6 +24,7 @@ import seedu.modsuni.logic.commands.HelpCommand;
 import seedu.modsuni.logic.commands.HistoryCommand;
 import seedu.modsuni.logic.commands.ListCommand;
 import seedu.modsuni.logic.commands.LoginCommand;
+import seedu.modsuni.logic.commands.LogoutCommand;
 import seedu.modsuni.logic.commands.RedoCommand;
 import seedu.modsuni.logic.commands.RegisterCommand;
 import seedu.modsuni.logic.commands.RemoveModuleFromDatabaseCommand;
@@ -141,6 +142,9 @@ public class ModsUniParser {
 
         case LoginCommand.COMMAND_WORD:
             return new LoginCommandParser().parse(arguments);
+
+        case LogoutCommand.COMMAND_WORD:
+            return new LogoutCommand();
 
         case EditStudentCommand.COMMAND_WORD:
             return new EditStudentCommandParser().parse(arguments);

--- a/src/main/java/seedu/modsuni/model/Model.java
+++ b/src/main/java/seedu/modsuni/model/Model.java
@@ -258,6 +258,11 @@ public interface Model {
     User getCurrentUser();
 
     /**
+     * Reset user details
+     */
+    void resetCurrentUser();
+
+    /**
      * Saves the current user.
      */
     void saveUserFile(User user, Path savePath);

--- a/src/main/java/seedu/modsuni/model/ModelManager.java
+++ b/src/main/java/seedu/modsuni/model/ModelManager.java
@@ -440,9 +440,9 @@ public class ModelManager extends ComponentManager implements Model {
 
     @Override
     public void resetCurrentUser() {
-        currentUser = null;
-        ((ModuleList) stagedModuleList).resetData(new ModuleList());
-        ((ModuleList) takenModuleList).resetData(new ModuleList());
+        currentUser = null; (
+        (ModuleList) stagedModuleList).resetData(new ModuleList()); (
+                (ModuleList) takenModuleList).resetData(new ModuleList());
     }
 
     //============= Generate Methods ============================

--- a/src/main/java/seedu/modsuni/model/ModelManager.java
+++ b/src/main/java/seedu/modsuni/model/ModelManager.java
@@ -438,6 +438,13 @@ public class ModelManager extends ComponentManager implements Model {
         return currentUser;
     }
 
+    @Override
+    public void resetCurrentUser() {
+        currentUser = null;
+        ((ModuleList) stagedModuleList).resetData(new ModuleList());
+        ((ModuleList) takenModuleList).resetData(new ModuleList());
+    }
+
     //============= Generate Methods ============================
 
     @Override

--- a/src/main/java/seedu/modsuni/ui/UserTab.java
+++ b/src/main/java/seedu/modsuni/ui/UserTab.java
@@ -14,6 +14,7 @@ import javafx.scene.layout.Region;
 import javafx.scene.text.Text;
 import seedu.modsuni.commons.core.LogsCenter;
 import seedu.modsuni.commons.events.ui.UserTabChangedEvent;
+import seedu.modsuni.commons.events.ui.UserTabLogoutEvent;
 import seedu.modsuni.model.user.Admin;
 import seedu.modsuni.model.user.Role;
 import seedu.modsuni.model.user.student.Student;
@@ -64,15 +65,31 @@ public class UserTab extends UiPart<Region> {
         registerAsAnEventHandler(this);
     }
 
+    /**
+     * Resets the respective UI fields in User Tab
+     */
+    private void resetUserTab() {
+        // Resets all Text value
+        userNameText.setText("");
+        dateText.setText("");
+        userDetailText1.setText("");
+        userDetailText2.setText("");
+        lastSavedText.setText("");
+
+        // Resets Label value
+        userDetailLabel1.setText("Major(s):");
+        userDetailLabel2.setText("Minor(s):");
+    }
+
     @Subscribe
     public void handleUserTabChangedEvent(UserTabChangedEvent event) {
-
+        logger.info(LogsCenter.getEventHandlingLogMessage(event));
         userNameText.setText(event.currentUser.getName().fullName);
 
         if (event.currentUser.getRole() == Role.STUDENT) {
             userDetailLabel1.setText("Major(s):");
             userDetailLabel2.setText("Minor(s):");
-            dateText.setText(((Student) event.currentUser).getEnrollmentDate().enrollmentDate);
+            dateText.setText(((Student) event.currentUser).getEnrollmentDate().toString());
             userDetailText1.setText(((Student) event.currentUser).getMajor().toString());
             userDetailText2.setText(((Student) event.currentUser).getMinor().toString());
         } else {
@@ -81,10 +98,14 @@ public class UserTab extends UiPart<Region> {
             dateText.setText(((Admin) event.currentUser).getEmploymentDate().toString());
             userDetailText1.setText(((Admin) event.currentUser).getSalary().toString());
             userDetailText2.setText("This is an admin account"); // hides secondary detail
-
         }
 
         lastSavedText.setText(dateFormat.format(new Date(clock.millis())));
+    }
 
+    @Subscribe
+    public void handleUserTabLogoutEvent(UserTabLogoutEvent event) {
+        logger.info(LogsCenter.getEventHandlingLogMessage(event));
+        resetUserTab();
     }
 }

--- a/src/test/java/seedu/modsuni/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/modsuni/logic/commands/AddCommandTest.java
@@ -312,6 +312,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public void resetCurrentUser() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void setCurrentUser(User user) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/modsuni/logic/commands/AddModuleToDatabaseCommandTest.java
+++ b/src/test/java/seedu/modsuni/logic/commands/AddModuleToDatabaseCommandTest.java
@@ -329,6 +329,11 @@ public class AddModuleToDatabaseCommandTest {
         }
 
         @Override
+        public void resetCurrentUser() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void setCurrentUser(User user) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/modsuni/logic/commands/AddModuleToStudentStagedCommandTest.java
+++ b/src/test/java/seedu/modsuni/logic/commands/AddModuleToStudentStagedCommandTest.java
@@ -437,6 +437,11 @@ public class AddModuleToStudentStagedCommandTest {
         }
 
         @Override
+        public void resetCurrentUser() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void setCurrentUser(User user) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/modsuni/logic/commands/AddModuleToStudentTakenCommandTest.java
+++ b/src/test/java/seedu/modsuni/logic/commands/AddModuleToStudentTakenCommandTest.java
@@ -437,6 +437,11 @@ public class AddModuleToStudentTakenCommandTest {
         }
 
         @Override
+        public void resetCurrentUser() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void setCurrentUser(User user) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/modsuni/logic/commands/GenerateCommandTest.java
+++ b/src/test/java/seedu/modsuni/logic/commands/GenerateCommandTest.java
@@ -387,6 +387,11 @@ public class GenerateCommandTest {
         }
 
         @Override
+        public void resetCurrentUser() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void setCurrentUser(User user) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/modsuni/logic/commands/LogoutCommandTest.java
+++ b/src/test/java/seedu/modsuni/logic/commands/LogoutCommandTest.java
@@ -1,0 +1,70 @@
+package seedu.modsuni.logic.commands;
+
+import static seedu.modsuni.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.modsuni.testutil.TypicalCredentials.getTypicalCredentialStore;
+import static seedu.modsuni.testutil.TypicalModules.getTypicalModuleList;
+import static seedu.modsuni.testutil.TypicalUsers.STUDENT_MAX;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import seedu.modsuni.logic.CommandHistory;
+import seedu.modsuni.logic.commands.exceptions.CommandException;
+import seedu.modsuni.model.AddressBook;
+import seedu.modsuni.model.Model;
+import seedu.modsuni.model.ModelManager;
+import seedu.modsuni.model.UserPrefs;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for ListCommand.
+ */
+public class LogoutCommandTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private Model model;
+    private Model expectedModel;
+    private CommandHistory commandHistory = new CommandHistory();
+
+    @Before
+    public void setUp() {
+        model = new ModelManager(getTypicalModuleList(), new AddressBook(), new UserPrefs(),
+            getTypicalCredentialStore());
+
+        expectedModel = new ModelManager(model.getModuleList(), model.getAddressBook(), new UserPrefs(),
+            model.getCredentialStore());
+    }
+
+    @Test
+    public void executeModelNullThrowsNullPointerException() throws NullPointerException, CommandException {
+
+        model = null;
+
+        LogoutCommand logoutCommand = new LogoutCommand();
+        thrown.expect(NullPointerException.class);
+        logoutCommand.execute(model, commandHistory);
+    }
+
+    @Test
+    public void executeNullCurrentUserThrowsCommandException() throws CommandException {
+
+        LogoutCommand logoutCommand = new LogoutCommand();
+
+        thrown.expect(CommandException.class);
+        thrown.expectMessage(LogoutCommand.MESSAGE_NOT_LOGGED_IN);
+
+        logoutCommand.execute(model, commandHistory);
+    }
+
+    @Test
+    public void executeLogoutSuccess() {
+        model.setCurrentUser(STUDENT_MAX);
+        assertCommandSuccess(new LogoutCommand(), model, commandHistory,
+            LogoutCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+
+}

--- a/src/test/java/seedu/modsuni/logic/commands/RemoveModuleFromDatabaseCommandTest.java
+++ b/src/test/java/seedu/modsuni/logic/commands/RemoveModuleFromDatabaseCommandTest.java
@@ -336,6 +336,11 @@ public class RemoveModuleFromDatabaseCommandTest {
         }
 
         @Override
+        public void resetCurrentUser() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void setCurrentUser(User user) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/modsuni/logic/commands/RemoveModuleFromStudentStagedCommandTest.java
+++ b/src/test/java/seedu/modsuni/logic/commands/RemoveModuleFromStudentStagedCommandTest.java
@@ -437,6 +437,11 @@ public class RemoveModuleFromStudentStagedCommandTest {
         }
 
         @Override
+        public void resetCurrentUser() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void setCurrentUser(User user) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/modsuni/logic/commands/RemoveModuleFromStudentTakenCommandTest.java
+++ b/src/test/java/seedu/modsuni/logic/commands/RemoveModuleFromStudentTakenCommandTest.java
@@ -438,6 +438,11 @@ public class RemoveModuleFromStudentTakenCommandTest {
         }
 
         @Override
+        public void resetCurrentUser() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void setCurrentUser(User user) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/modsuni/logic/commands/RemoveUserCommandTest.java
+++ b/src/test/java/seedu/modsuni/logic/commands/RemoveUserCommandTest.java
@@ -336,6 +336,11 @@ public class RemoveUserCommandTest {
         }
 
         @Override
+        public void resetCurrentUser() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void setCurrentUser(User user) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/modsuni/logic/commands/SearchCommandTest.java
+++ b/src/test/java/seedu/modsuni/logic/commands/SearchCommandTest.java
@@ -295,6 +295,11 @@ public class SearchCommandTest {
         }
 
         @Override
+        public void resetCurrentUser() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void setCurrentUser(User user) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/modsuni/logic/parser/ModsUniParserTest.java
+++ b/src/test/java/seedu/modsuni/logic/parser/ModsUniParserTest.java
@@ -4,11 +4,16 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static seedu.modsuni.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.modsuni.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.modsuni.logic.commands.CommandTestUtil.VALID_PASSWORD;
+import static seedu.modsuni.logic.commands.CommandTestUtil.VALID_PATH;
 import static seedu.modsuni.logic.commands.CommandTestUtil.VALID_USERNAME;
+import static seedu.modsuni.testutil.TypicalCredentials.CREDENTIAL_STUDENT_MAX;
 import static seedu.modsuni.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.modsuni.testutil.TypicalSavePaths.PATH_USERDATA_MAX;
 import static seedu.modsuni.testutil.TypicalSavePaths.PATH_USERDATA_SEB;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -30,6 +35,8 @@ import seedu.modsuni.logic.commands.GenerateCommand;
 import seedu.modsuni.logic.commands.HelpCommand;
 import seedu.modsuni.logic.commands.HistoryCommand;
 import seedu.modsuni.logic.commands.ListCommand;
+import seedu.modsuni.logic.commands.LoginCommand;
+import seedu.modsuni.logic.commands.LogoutCommand;
 import seedu.modsuni.logic.commands.RedoCommand;
 import seedu.modsuni.logic.commands.RegisterCommand;
 import seedu.modsuni.logic.commands.RemoveModuleFromDatabaseCommand;
@@ -47,6 +54,7 @@ import seedu.modsuni.model.user.student.Student;
 import seedu.modsuni.testutil.AdminBuilder;
 import seedu.modsuni.testutil.AdminUtil;
 import seedu.modsuni.testutil.CredentialBuilder;
+import seedu.modsuni.testutil.CredentialUtil;
 import seedu.modsuni.testutil.EditStudentDescriptorBuilder;
 import seedu.modsuni.testutil.ModuleBuilder;
 import seedu.modsuni.testutil.ModuleUtil;
@@ -134,6 +142,30 @@ public class ModsUniParserTest {
     public void parseCommand_list() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+    }
+
+
+    @Test
+    public void parseCommand_login() throws Exception {
+        Credential validCredential = new CredentialBuilder(CREDENTIAL_STUDENT_MAX)
+            .withPassword(VALID_PASSWORD)
+            .build();
+        Path validPath = Paths.get(VALID_PATH);
+
+        // Updates validCredential with hashed password
+        validCredential = new CredentialBuilder(validCredential)
+            .withPassword(ParserUtil.parsePassword(VALID_PASSWORD).toString())
+            .build();
+
+        LoginCommand command =
+            (LoginCommand) parser.parseCommand(CredentialUtil.getLoginCommand(validCredential));
+
+        assertEquals(new LoginCommand(validCredential, validPath), command);
+    }
+
+    @Test
+    public void parseCommand_logout() throws Exception {
+        assertTrue(parser.parseCommand(LogoutCommand.COMMAND_WORD) instanceof LogoutCommand);
     }
 
     @Test

--- a/src/test/java/seedu/modsuni/testutil/CredentialUtil.java
+++ b/src/test/java/seedu/modsuni/testutil/CredentialUtil.java
@@ -1,0 +1,27 @@
+package seedu.modsuni.testutil;
+
+import static seedu.modsuni.logic.commands.CommandTestUtil.VALID_PASSWORD;
+import static seedu.modsuni.logic.commands.CommandTestUtil.VALID_PATH;
+import static seedu.modsuni.logic.parser.CliSyntax.PREFIX_PASSWORD;
+import static seedu.modsuni.logic.parser.CliSyntax.PREFIX_USERDATA;
+import static seedu.modsuni.logic.parser.CliSyntax.PREFIX_USERNAME;
+
+import seedu.modsuni.logic.commands.LoginCommand;
+import seedu.modsuni.model.credential.Credential;
+
+/**
+ * A utility class for Admin.
+ */
+public class CredentialUtil {
+
+    /**
+     * Returns a login command string.
+     */
+    public static String getLoginCommand(Credential credential) {
+
+        return LoginCommand.COMMAND_WORD + " "
+            + PREFIX_USERNAME + credential.getUsername().toString() + " "
+            + PREFIX_PASSWORD + VALID_PASSWORD + " "
+            + PREFIX_USERDATA + VALID_PATH;
+    }
+}


### PR DESCRIPTION
In this PR, the logout command has been implemented. The `LogoutCommand` allows users to disassociate current user specific details from the application, effectively resetting the application to its original state.

**Logic**
 - `LogoutCommand` has been included. Tentatively, executing the command will not only reset user-specific data from within `Model` but also reset the necessary UI panes to its original state(on startup)

**Model**
- An additional method has been included in `ModelManager` to facilitate the logout process.

**UI**
- A new event `UserTabLogoutEvent` has been included to reset the `Label` and `Text` in `UserTab`
- A handler method has been included in `UserTab` to perform the execution of the aforementioned process

The following issues have also been resolved:
- Resolves #226 