### PR TITLE
Bug fix for module storage

### DIFF
--- a/src/main/java/seedu/modsuni/storage/XmlAdaptedAnd.java
+++ b/src/main/java/seedu/modsuni/storage/XmlAdaptedAnd.java
@@ -32,6 +32,31 @@ public class XmlAdaptedAnd {
         or = new ArrayList<>();
     }
 
+    /**
+     * Converts a given PrereqDetails into this class for JAXB use.
+     *
+     * @param source future changes to this will not affect the created XmlAdaptedAnd
+     */
+    public XmlAdaptedAnd(PrereqDetails source) {
+        if (source.getAnd().isPresent()) {
+            and = new ArrayList<>();
+            List<PrereqDetails> prereqDetails = source.getAnd().get();
+            for (PrereqDetails element: prereqDetails) {
+                and.add(new XmlAdaptedAnd(element));
+            }
+        }
+        if (source.getOr().isPresent()) {
+            or = new ArrayList<>();
+            List<PrereqDetails> prereqDetails = source.getOr().get();
+            for (PrereqDetails element: prereqDetails) {
+                or.add(new XmlAdaptedOr(element));
+            }
+        }
+        if (source.getCode().isPresent()) {
+            code = source.getCode().get().code;
+        }
+    }
+
     public String getCode() {
         return code;
     }

--- a/src/main/java/seedu/modsuni/storage/XmlAdaptedModule.java
+++ b/src/main/java/seedu/modsuni/storage/XmlAdaptedModule.java
@@ -88,6 +88,7 @@ public class XmlAdaptedModule {
         lockedModules = source.getLockedModules().stream()
                 .map(XmlAdaptedLockedModules::new)
                 .collect(Collectors.toList());
+        parsedPrereq = new XmlAdaptedPrereq(source.getPrereq());
     }
 
     /**

--- a/src/main/java/seedu/modsuni/storage/XmlAdaptedOr.java
+++ b/src/main/java/seedu/modsuni/storage/XmlAdaptedOr.java
@@ -30,6 +30,31 @@ public class XmlAdaptedOr {
         or = new ArrayList<>();
     }
 
+    /**
+     * Converts a given PrereqDetails into this class for JAXB use.
+     *
+     * @param source future changes to this will not affect the created XmlAdaptedOr
+     */
+    public XmlAdaptedOr(PrereqDetails source) {
+        if (source.getAnd().isPresent()) {
+            and = new ArrayList<>();
+            List<PrereqDetails> prereqDetails = source.getAnd().get();
+            for (PrereqDetails element: prereqDetails) {
+                and.add(new XmlAdaptedAnd(element));
+            }
+        }
+        if (source.getOr().isPresent()) {
+            or = new ArrayList<>();
+            List<PrereqDetails> prereqDetails = source.getOr().get();
+            for (PrereqDetails element: prereqDetails) {
+                or.add(new XmlAdaptedOr(element));
+            }
+        }
+        if (source.getCode().isPresent()) {
+            code = source.getCode().get().code;
+        }
+    }
+
     public String getCode() {
         return code;
     }

--- a/src/main/java/seedu/modsuni/storage/XmlAdaptedPrereq.java
+++ b/src/main/java/seedu/modsuni/storage/XmlAdaptedPrereq.java
@@ -24,6 +24,28 @@ public class XmlAdaptedPrereq {
     }
 
     /**
+     * Converts a given Prereq into this class for JAXB use.
+     *
+     * @param source future changes to this will not affect the created XmlAdaptedPrereq
+     */
+    public XmlAdaptedPrereq(Prereq source) {
+        if (source.getAnd().isPresent()) {
+            and = new ArrayList<>();
+            List<PrereqDetails> prereqDetails = source.getAnd().get();
+            for (PrereqDetails element: prereqDetails) {
+                and.add(new XmlAdaptedAnd(element));
+            }
+        }
+        if (source.getOr().isPresent()) {
+            or = new ArrayList<>();
+            List<PrereqDetails> prereqDetails = source.getOr().get();
+            for (PrereqDetails element: prereqDetails) {
+                or.add(new XmlAdaptedOr(element));
+            }
+        }
+    }
+
+    /**
      * Converts this jaxb-friendly adapted prereq object into the model's Module object.
      *
      * @throws IllegalValueException if there were any data constraints violated in the adapted prereq code


### PR DESCRIPTION
This PR is part of milestone v1.4. In this PR, the xml adapted storage classes has been updated to add in the prerequisite data from a module.

**Storage**
`XmlAdaptedAnd`, `XmlAdaptedOr`, `XmlAdaptedModule`, `XmlAdaptedPrereq` has been updated to include the module's prerequisite data.

The following issue has also been resolved:
Resolves #229 